### PR TITLE
Update Artisan Command to use Laravel Prompts

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,12 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.1]
-        laravel: [9.*, 10.*]
+        laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
-            carbon: ^2.63
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
-            testbench: 8.*
+            testbench: ^8.13
             carbon: ^2.63
 
     services:

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ coverage
 docs
 phpunit.xml
 phpstan.neon
-testbench.yaml
 vendor
 node_modules
 database/database.sqlite

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A package to restore a database backup created by the [spatie/laravel-backup](https://github.com/spatie/laravel-backup) package.
 
+The package requires Laravel 10.17 or higher and PHP 8.1 or higher.
+
 ## Installation
 
 You can install the package via composer:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A package to restore a database backup created by the [spatie/laravel-backup](https://github.com/spatie/laravel-backup) package.
 
-The package requires Laravel 10.17 or higher and PHP 8.1 or higher.
+The package requires Laravel v10.17 or higher and PHP 8.1 or higher.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,14 @@ For MySQL and PostgreSQL the package expects that a `laravel_backup_restore` dat
 
 You can change user, password and database by passing ENV-variables to the shell command tp run the tests … or change the settings locally to your needs. See [TestCase](https://github.com/stefanzweifel/laravel-backup-restore/blob/main/tests/TestCase.php) for details.
 
+### Testing with Testbench
+
+You can invoke the `backup:restore` command using `testbench` to test the command like you would in a Laravel application. 
+
+```php
+vendor/bin/testbench backup:restore --disk=remote
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.1",
         "ext-zip": "*",
         "illuminate/contracts": "^10.17.0",
-        "laravel/prompts": "^0.1.3",
+        "laravel/prompts": "^0.1.11",
         "spatie/laravel-backup": "^8.0",
         "spatie/laravel-package-tools": "^1.14.0",
         "spatie/temporary-directory": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": "^8.1",
         "ext-zip": "*",
         "illuminate/contracts": "^9.0 || ^10.0",
+        "laravel/prompts": "^0.1.3",
         "spatie/laravel-backup": "^8.0",
         "spatie/laravel-package-tools": "^1.14.0",
         "spatie/temporary-directory": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "ext-zip": "*",
-        "illuminate/contracts": "^9.0 || ^10.0",
+        "illuminate/contracts": "^10.0",
         "laravel/prompts": "^0.1.3",
         "spatie/laravel-backup": "^8.0",
         "spatie/laravel-package-tools": "^1.14.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^6.0 || ^7.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^8.13",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "pestphp/pest-plugin-watch": "1.x-dev",
@@ -45,15 +45,31 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Wnx\\LaravelBackupRestore\\Tests\\": "tests"
+            "Wnx\\LaravelBackupRestore\\Tests\\": "tests",
+            "Workbench\\App\\": "workbench/app/"
         }
     },
     "scripts": {
-        "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
+        "post-autoload-dump": [
+            "@clear",
+            "@prepare",
+            "@php ./vendor/bin/testbench package:discover --ansi"
+        ],
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/pint"
+        "format": "vendor/bin/pint",
+        "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
+        "prepare": "@php vendor/bin/testbench package:discover --ansi",
+        "build": "@php vendor/bin/testbench workbench:build --ansi",
+        "serve": [
+            "@build",
+            "@php vendor/bin/testbench serve"
+        ],
+        "lint": [
+            "@php vendor/bin/pint",
+            "@php vendor/bin/phpstan analyse"
+        ]
     },
     "config": {
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "ext-zip": "*",
-        "illuminate/contracts": "^10.0",
+        "illuminate/contracts": "^10.17.0",
         "laravel/prompts": "^0.1.3",
         "spatie/laravel-backup": "^8.0",
         "spatie/laravel-package-tools": "^1.14.0",

--- a/src/Actions/DecompressBackupAction.php
+++ b/src/Actions/DecompressBackupAction.php
@@ -9,6 +9,8 @@ use Wnx\LaravelBackupRestore\Exceptions\DecompressionFailed;
 use Wnx\LaravelBackupRestore\PendingRestore;
 use ZipArchive;
 
+use function Laravel\Prompts\info;
+
 class DecompressBackupAction
 {
     /**
@@ -21,7 +23,7 @@ class DecompressBackupAction
         $pathToFileToDecompress = Storage::disk($pendingRestore->restoreDisk)
             ->path($pendingRestore->getPathToLocalCompressedBackup());
 
-        consoleOutput()->info('Extracting database dump from backup …');
+        info('Extracting database dump from backup …');
 
         $zip = new ZipArchive;
         $result = $zip->open($pathToFileToDecompress);

--- a/src/Actions/DecompressBackupAction.php
+++ b/src/Actions/DecompressBackupAction.php
@@ -10,6 +10,7 @@ use Wnx\LaravelBackupRestore\PendingRestore;
 use ZipArchive;
 
 use function Laravel\Prompts\info;
+use function Laravel\Prompts\spin;
 
 class DecompressBackupAction
 {
@@ -23,8 +24,6 @@ class DecompressBackupAction
         $pathToFileToDecompress = Storage::disk($pendingRestore->restoreDisk)
             ->path($pendingRestore->getPathToLocalCompressedBackup());
 
-        info('Extracting database dump from backup …');
-
         $zip = new ZipArchive;
         $result = $zip->open($pathToFileToDecompress);
 
@@ -33,12 +32,16 @@ class DecompressBackupAction
                 $zip->setPassword($pendingRestore->backupPassword);
             }
 
-            $extractionResult = $zip->extractTo($extractTo);
-            $zip->close();
+            spin(function () use ($pathToFileToDecompress, $extractTo, $zip) {
+                $extractionResult = $zip->extractTo($extractTo);
+                $zip->close();
 
-            if ($extractionResult === false) {
-                throw DecompressionFailed::create($extractionResult, $pathToFileToDecompress);
-            }
+                if ($extractionResult === false) {
+                    throw DecompressionFailed::create($extractionResult, $pathToFileToDecompress);
+                }
+            }, 'Extracting database dump from backup …');
+
+            info('Extracted database dump from backup.');
         } else {
             throw DecompressionFailed::create($result, $pathToFileToDecompress);
         }

--- a/src/Actions/DownloadBackupAction.php
+++ b/src/Actions/DownloadBackupAction.php
@@ -7,16 +7,21 @@ namespace Wnx\LaravelBackupRestore\Actions;
 use Illuminate\Support\Facades\Storage;
 use Wnx\LaravelBackupRestore\PendingRestore;
 
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\spin;
+
 class DownloadBackupAction
 {
     public function execute(PendingRestore $pendingRestore): void
     {
-        consoleOutput()->info('Downloading backup …');
+        spin(function () use ($pendingRestore) {
+            Storage::disk($pendingRestore->restoreDisk)
+                ->writeStream(
+                    $pendingRestore->getPathToLocalCompressedBackup(),
+                    Storage::disk($pendingRestore->disk)->readStream($pendingRestore->backup)
+                );
+        }, 'Downloading backup …');
 
-        Storage::disk($pendingRestore->restoreDisk)
-            ->writeStream(
-                $pendingRestore->getPathToLocalCompressedBackup(),
-                Storage::disk($pendingRestore->disk)->readStream($pendingRestore->backup)
-            );
+        info("Backup downloaded to {$pendingRestore->getPathToLocalCompressedBackup()}.");
     }
 }

--- a/src/Actions/ImportDumpAction.php
+++ b/src/Actions/ImportDumpAction.php
@@ -12,6 +12,8 @@ use Wnx\LaravelBackupRestore\Exceptions\ImportFailed;
 use Wnx\LaravelBackupRestore\Exceptions\NoDatabaseDumpsFound;
 use Wnx\LaravelBackupRestore\PendingRestore;
 
+use function Laravel\Prompts\info;
+
 class ImportDumpAction
 {
     /**
@@ -29,10 +31,10 @@ class ImportDumpAction
 
         $dbDumps = $pendingRestore->getAvailableDbDumps();
 
-        consoleOutput()->info('Importing database '.str('dump')->plural($dbDumps)->__toString().' …');
+        info('Importing database '.str('dump')->plural($dbDumps)->__toString().' …');
 
         $dbDumps->each(function ($dbDump) use ($pendingRestore, $importer) {
-            consoleOutput()->info('Importing '.str($dbDump)->afterLast('/')->__toString());
+            info('Importing '.str($dbDump)->afterLast('/')->__toString());
             $absolutePathToDump = Storage::disk($pendingRestore->restoreDisk)->path($dbDump);
             $importer->importToDatabase($absolutePathToDump);
         });

--- a/src/Actions/ResetDatabaseAction.php
+++ b/src/Actions/ResetDatabaseAction.php
@@ -8,11 +8,13 @@ use Illuminate\Support\Facades\DB;
 use Wnx\LaravelBackupRestore\Events\DatabaseReset;
 use Wnx\LaravelBackupRestore\PendingRestore;
 
+use function Laravel\Prompts\info;
+
 class ResetDatabaseAction
 {
     public function execute(PendingRestore $pendingRestore)
     {
-        consoleOutput()->info('Reset database …');
+        info('Reset database …');
 
         DB::connection($pendingRestore->connection)
             ->getSchemaBuilder()

--- a/src/Commands/RestoreCommand.php
+++ b/src/Commands/RestoreCommand.php
@@ -8,9 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use function Laravel\Prompts\password;
 use Laravel\Prompts\Prompt;
-use function Laravel\Prompts\select;
 use Wnx\LaravelBackupRestore\Actions\CheckDependenciesAction;
 use Wnx\LaravelBackupRestore\Actions\CleanupLocalBackupAction;
 use Wnx\LaravelBackupRestore\Actions\DecompressBackupAction;
@@ -26,6 +24,9 @@ use Wnx\LaravelBackupRestore\Exceptions\NoDatabaseDumpsFound;
 use Wnx\LaravelBackupRestore\HealthChecks\HealthCheck;
 use Wnx\LaravelBackupRestore\HealthChecks\Result;
 use Wnx\LaravelBackupRestore\PendingRestore;
+
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\select;
 
 class RestoreCommand extends Command
 {

--- a/src/Commands/RestoreCommand.php
+++ b/src/Commands/RestoreCommand.php
@@ -25,6 +25,7 @@ use Wnx\LaravelBackupRestore\HealthChecks\HealthCheck;
 use Wnx\LaravelBackupRestore\HealthChecks\Result;
 use Wnx\LaravelBackupRestore\PendingRestore;
 
+use function Laravel\Prompts\info;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\select;
 
@@ -87,7 +88,7 @@ class RestoreCommand extends Command
 
         $importDumpAction->execute($pendingRestore);
 
-        $this->info('Cleaning up …');
+        info('Cleaning up …');
         $cleanupLocalBackupAction->execute($pendingRestore);
 
         return $this->runHealthChecks($pendingRestore);
@@ -122,7 +123,7 @@ class RestoreCommand extends Command
     {
         $name = config('backup.backup.name');
 
-        $this->info("Fetch list of backups from $disk …");
+        info("Fetch list of backups from $disk …");
         $listOfBackups = collect(Storage::disk($disk)->allFiles($name))
             ->filter(fn ($file) => Str::endsWith($file, '.zip'));
 
@@ -176,7 +177,7 @@ class RestoreCommand extends Command
             return self::FAILURE;
         }
 
-        $this->info('All health checks passed.');
+        info('All health checks passed.');
 
         return self::SUCCESS;
     }

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,0 +1,2 @@
+providers:
+  - Workbench\App\BackupRestoreWorkbenchProvider

--- a/tests/Commands/RestoreCommandTest.php
+++ b/tests/Commands/RestoreCommandTest.php
@@ -18,7 +18,7 @@ it('restores mysql database', function (string $backup, string $password = null)
         '--no-interaction' => true,
     ])
         ->expectsQuestion("Proceed to restore \"{$backup}\" using the \"mysql-restore\" database connection. (Host: 127.0.0.1, Database: laravel_backup_restore, username: root)", true)
-        ->expectsOutput('All health checks passed.')
+        ->expectsOutputToContain('All health checks passed.')
         ->assertSuccessful();
 
     $result = DB::connection('mysql')->table('users')->count();
@@ -172,6 +172,6 @@ it('shows error message if health check after import fails', function () {
         '--reset' => true,
     ])
         ->expectsQuestion('Proceed to restore "Laravel/2023-01-28-mysql-no-compression-no-encryption-empty-dump.zip" using the "mysql" database connection. (Host: 127.0.0.1, Database: laravel_backup_restore, username: root)', true)
-        ->expectsOutput('Database has not tables after restore.')
+        ->expectsOutputToContain('Database has not tables after restore.')
         ->assertFailed();
 });

--- a/tests/Commands/RestoreCommandTest.php
+++ b/tests/Commands/RestoreCommandTest.php
@@ -9,7 +9,7 @@ use Wnx\LaravelBackupRestore\Events\DatabaseReset;
 use Wnx\LaravelBackupRestore\Exceptions\NoBackupsFound;
 
 // MySQL
-it('restores mysql database', function (string $backup, ?string $password = null) {
+it('restores mysql database', function (string $backup, string $password = null) {
     $this->artisan(RestoreCommand::class, [
         '--disk' => 'remote',
         '--backup' => $backup,
@@ -42,7 +42,7 @@ it('restores mysql database', function (string $backup, ?string $password = null
 ])->group('mysql');
 
 // sqlite
-it('restores sqlite database', function (string $backup, ?string $password = null) {
+it('restores sqlite database', function (string $backup, string $password = null) {
     $this->artisan(RestoreCommand::class, [
         '--disk' => 'remote',
         '--backup' => $backup,
@@ -74,7 +74,7 @@ it('restores sqlite database', function (string $backup, ?string $password = nul
 ])->group('sqlite');
 
 // pgsql
-it('restores pgsql database', function (string $backup, ?string $password = null) {
+it('restores pgsql database', function (string $backup, string $password = null) {
     $this->artisan(RestoreCommand::class, [
         '--disk' => 'remote',
         '--backup' => $backup,

--- a/workbench/app/BackupRestoreWorkbenchProvider.php
+++ b/workbench/app/BackupRestoreWorkbenchProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App;
+
+use Illuminate\Support\ServiceProvider;
+
+class BackupRestoreWorkbenchProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        // Setup default database to use sqlite :memory:
+        $this->app['config']->set('database.default', 'sqlite');
+        $this->app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => 'database/database.sqlite',
+        ]);
+        $this->app['config']->set('database.connections.sqlite-restore', [
+            'driver' => 'sqlite',
+            'database' => 'database/database.sqlite',
+        ]);
+
+        $this->app['config']->set('database.connections.mysql', [
+            'driver' => 'mysql',
+            'host' => env('MYSQL_HOST', '127.0.0.1'),
+            'port' => env('MYSQL_PORT', '3306'),
+            'database' => env('MYSQL_DATABASE', 'laravel_backup_restore'),
+            'username' => env('MYSQL_USERNAME', 'root'),
+            'password' => env('MYSQL_PASSWORD', ''),
+        ]);
+
+        $this->app['config']->set('database.connections.mysql-restore', [
+            'driver' => 'mysql',
+            'host' => env('MYSQL_HOST', '127.0.0.1'),
+            'port' => env('MYSQL_PORT', '3306'),
+            'database' => env('MYSQL_DATABASE', 'laravel_backup_restore'),
+            'username' => env('MYSQL_USERNAME', 'root'),
+            'password' => env('MYSQL_PASSWORD', ''),
+        ]);
+
+        $this->app['config']->set('database.connections.pgsql', [
+            'driver' => 'pgsql',
+            'host' => env('PGSQL_HOST', '127.0.0.1'),
+            'port' => env('PGSQL_PORT', '5432'),
+            'database' => env('PGSQL_DATABASE', 'laravel_backup_restore'),
+            'username' => env('PGSQL_USERNAME', 'root'),
+            'password' => env('PGSQL_PASSWORD', ''),
+            'search_path' => 'public',
+        ]);
+        $this->app['config']->set('database.connections.pgsql-restore', [
+            'driver' => 'pgsql',
+            'host' => env('PGSQL_HOST', '127.0.0.1'),
+            'port' => env('PGSQL_PORT', '5432'),
+            'database' => env('PGSQL_DATABASE', 'laravel_backup_restore'),
+            'username' => env('PGSQL_USERNAME', 'root'),
+            'password' => env('PGSQL_PASSWORD', ''),
+            'search_path' => 'public',
+        ]);
+
+        $this->app['config']->set('database.connections.unsupported-driver', [
+            'driver' => 'sqlsrv',
+        ]);
+
+        // Setup default filesystem disk where "remote" backups are stored
+        $this->app['config']->set('filesystems.disks.remote', [
+            'driver' => 'local',
+            'root' => __DIR__.'/../../tests/storage',
+        ]);
+
+        // Setup configuration for spatie/laravel-backup package that is relevant for this package
+        $this->app['config']->set('backup', [
+            'backup' => [
+                'name' => env('APP_NAME', 'Laravel'),
+                'source' => [
+                    'databases' => [
+                        'mysql',
+                    ],
+                ],
+                'database_dump_compressor' => \Spatie\DbDumper\Compressors\GzipCompressor::class,
+                'database_dump_file_extension' => '',
+
+                'destination' => [
+                    'filename_prefix' => '',
+                    'disks' => [
+                        'remote',
+                    ],
+                ],
+                'temporary_directory' => storage_path('app/backup-temp'),
+                'password' => env('BACKUP_ARCHIVE_PASSWORD'),
+                'encryption' => 'default',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
This PR updates the package to use Laravel Prompts for the CLI command.

- [x] Drop Laravel 9 support? done in #29 
- [x] Drop support for certain Laravel 10 versions?