### PR TITLE
Use Driver Name when creating DbImporter instead of Connection Name

### DIFF
--- a/src/DbImporterFactory.php
+++ b/src/DbImporterFactory.php
@@ -20,11 +20,13 @@ class DbImporterFactory
      */
     public static function createFromConnection(string $dbConnectionName): DbImporter
     {
-        if (config("database.connections.$dbConnectionName") === null) {
-            throw CannotCreateDbImporter::unsupportedDriver($dbConnectionName);
+        $config = config("database.connections.$dbConnectionName");
+
+        if ($config === null) {
+            throw CannotCreateDbImporter::configNotFound($dbConnectionName);
         }
 
-        return static::forDriver($dbConnectionName);
+        return static::forDriver($config['driver']);
     }
 
     /**

--- a/src/Exceptions/CannotCreateDbImporter.php
+++ b/src/Exceptions/CannotCreateDbImporter.php
@@ -8,6 +8,11 @@ use Exception;
 
 class CannotCreateDbImporter extends Exception
 {
+    public static function configNotFound(string $connectionName): self
+    {
+        return new static("Cannot find database connection `$connectionName` in config/database.php");
+    }
+
     public static function unsupportedDriver(string $driver): self
     {
         return new static("Cannot create a importer for database driver `$driver`. Use `mysql`, `pgsql` or `sqlite`.");

--- a/tests/Commands/RestoreCommandTest.php
+++ b/tests/Commands/RestoreCommandTest.php
@@ -13,11 +13,11 @@ it('restores mysql database', function (string $backup, string $password = null)
     $this->artisan(RestoreCommand::class, [
         '--disk' => 'remote',
         '--backup' => $backup,
-        '--connection' => 'mysql',
+        '--connection' => 'mysql-restore',
         '--password' => $password,
         '--no-interaction' => true,
     ])
-        ->expectsQuestion("Proceed to restore \"{$backup}\" using the \"mysql\" database connection. (Host: 127.0.0.1, Database: laravel_backup_restore, username: root)", true)
+        ->expectsQuestion("Proceed to restore \"{$backup}\" using the \"mysql-restore\" database connection. (Host: 127.0.0.1, Database: laravel_backup_restore, username: root)", true)
         ->expectsOutput('All health checks passed.')
         ->assertSuccessful();
 
@@ -46,11 +46,11 @@ it('restores sqlite database', function (string $backup, string $password = null
     $this->artisan(RestoreCommand::class, [
         '--disk' => 'remote',
         '--backup' => $backup,
-        '--connection' => 'sqlite',
+        '--connection' => 'sqlite-restore',
         '--password' => $password,
         '--no-interaction' => true,
     ])
-        ->expectsQuestion("Proceed to restore \"{$backup}\" using the \"sqlite\" database connection. (Database: database/database.sqlite)", true)
+        ->expectsQuestion("Proceed to restore \"{$backup}\" using the \"sqlite-restore\" database connection. (Database: database/database.sqlite)", true)
         ->assertSuccessful();
 
     $result = DB::connection('sqlite')->table('users')->count();
@@ -78,11 +78,11 @@ it('restores pgsql database', function (string $backup, string $password = null)
     $this->artisan(RestoreCommand::class, [
         '--disk' => 'remote',
         '--backup' => $backup,
-        '--connection' => 'pgsql',
+        '--connection' => 'pgsql-restore',
         '--password' => $password,
         '--no-interaction' => true,
     ])
-        ->expectsQuestion("Proceed to restore \"{$backup}\" using the \"pgsql\" database connection. (Host: 127.0.0.1, Database: laravel_backup_restore, username: root)", true)
+        ->expectsQuestion("Proceed to restore \"{$backup}\" using the \"pgsql-restore\" database connection. (Host: 127.0.0.1, Database: laravel_backup_restore, username: root)", true)
         ->assertSuccessful();
 
     $result = DB::connection('pgsql')->table('users')->count();

--- a/tests/DbImporterFactoryTest.php
+++ b/tests/DbImporterFactoryTest.php
@@ -37,3 +37,7 @@ it('returns db importer instances for given database driver', function ($connect
 it('throws exception if no db importer instance can be created for connection')
     ->tap(fn () => DbImporterFactory::createFromConnection('unsupported'))
     ->throws(CannotCreateDbImporter::class);
+
+it('throws exception if no db importer instance can be created for driver')
+    ->tap(fn () => DbImporterFactory::createFromConnection('unsupported-driver'))
+    ->throws(CannotCreateDbImporter::class);

--- a/tests/DbImporterFactoryTest.php
+++ b/tests/DbImporterFactoryTest.php
@@ -5,19 +5,31 @@ declare(strict_types=1);
 use Wnx\LaravelBackupRestore\DbImporterFactory;
 use Wnx\LaravelBackupRestore\Exceptions\CannotCreateDbImporter;
 
-it('returns db importer instances for given database driver', function ($driver, $expectedClass) {
-    expect(DbImporterFactory::createFromConnection($driver))->toBeInstanceOf($expectedClass);
+it('returns db importer instances for given database driver', function ($connectionName, $expectedClass) {
+    expect(DbImporterFactory::createFromConnection($connectionName))->toBeInstanceOf($expectedClass);
 })->with([
     [
-        'driver' => 'mysql',
+        'connectionName' => 'mysql',
         'expected' => \Wnx\LaravelBackupRestore\Databases\MySql::class,
     ],
     [
-        'driver' => 'sqlite',
+        'connectionName' => 'mysql-restore',
+        'expected' => \Wnx\LaravelBackupRestore\Databases\MySql::class,
+    ],
+    [
+        'connectionName' => 'sqlite',
         'expected' => \Wnx\LaravelBackupRestore\Databases\Sqlite::class,
     ],
     [
-        'driver' => 'pgsql',
+        'connectionName' => 'sqlite-restore',
+        'expected' => \Wnx\LaravelBackupRestore\Databases\Sqlite::class,
+    ],
+    [
+        'connectionName' => 'pgsql',
+        'expected' => \Wnx\LaravelBackupRestore\Databases\PostgreSql::class,
+    ],
+    [
+        'connectionName' => 'pgsql-restore',
         'expected' => \Wnx\LaravelBackupRestore\Databases\PostgreSql::class,
     ],
 ]);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,8 +3,9 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Storage;
-use function Pest\Laravel\artisan;
 use Wnx\LaravelBackupRestore\Tests\TestCase;
+
+use function Pest\Laravel\artisan;
 
 uses(TestCase::class)
     ->beforeEach(function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,10 @@ class TestCase extends Orchestra
             'driver' => 'sqlite',
             'database' => 'database/database.sqlite',
         ]);
+        $app['config']->set('database.connections.sqlite-restore', [
+            'driver' => 'sqlite',
+            'database' => 'database/database.sqlite',
+        ]);
 
         $app['config']->set('database.connections.mysql', [
             'driver' => 'mysql',
@@ -34,7 +38,25 @@ class TestCase extends Orchestra
             'password' => env('MYSQL_PASSWORD', ''),
         ]);
 
+        $app['config']->set('database.connections.mysql-restore', [
+            'driver' => 'mysql',
+            'host' => env('MYSQL_HOST', '127.0.0.1'),
+            'port' => env('MYSQL_PORT', '3306'),
+            'database' => env('MYSQL_DATABASE', 'laravel_backup_restore'),
+            'username' => env('MYSQL_USERNAME', 'root'),
+            'password' => env('MYSQL_PASSWORD', ''),
+        ]);
+
         $app['config']->set('database.connections.pgsql', [
+            'driver' => 'pgsql',
+            'host' => env('PGSQL_HOST', '127.0.0.1'),
+            'port' => env('PGSQL_PORT', '5432'),
+            'database' => env('PGSQL_DATABASE', 'laravel_backup_restore'),
+            'username' => env('PGSQL_USERNAME', 'root'),
+            'password' => env('PGSQL_PASSWORD', ''),
+            'search_path' => 'public',
+        ]);
+        $app['config']->set('database.connections.pgsql-restore', [
             'driver' => 'pgsql',
             'host' => env('PGSQL_HOST', '127.0.0.1'),
             'port' => env('PGSQL_PORT', '5432'),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -66,6 +66,10 @@ class TestCase extends Orchestra
             'search_path' => 'public',
         ]);
 
+        $app['config']->set('database.connections.unsupported-driver', [
+            'driver' => 'sqlsrv',
+        ]);
+
         // Setup default filesystem disk where "remote" backups are stored
         $app['config']->set('filesystems.disks.remote', [
             'driver' => 'local',


### PR DESCRIPTION
This PR fixes the `DbImporterFactory` to use the driver name – instead of connection name – to create a new instance of a DbImporter.

Fixes #22.
