### PR TITLE
Check if CLI Dependencies are available before starting restore process

### DIFF
--- a/src/Actions/CheckDependenciesAction.php
+++ b/src/Actions/CheckDependenciesAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wnx\LaravelBackupRestore\Actions;
+
+use Illuminate\Support\Facades\Process;
+use Wnx\LaravelBackupRestore\DbImporterFactory;
+use Wnx\LaravelBackupRestore\Exceptions\CannotCreateDbImporter;
+use Wnx\LaravelBackupRestore\Exceptions\CliNotFound;
+
+class CheckDependenciesAction
+{
+    /**
+     * @throws CannotCreateDbImporter
+     * @throws CliNotFound
+     * @throws \Throwable
+     */
+    public function execute(string $connection): void
+    {
+        $databaseCli = DbImporterFactory::createFromConnection($connection)->getCliName();
+
+        $this->checkIfCliExists($databaseCli);
+
+        $this->checkIfCliExists('gunzip');
+    }
+
+    /**
+     * @throws CliNotFound|\Throwable
+     */
+    protected function checkIfCliExists($cli): void
+    {
+        $result = Process::run(['which', $cli]);
+
+        throw_if($result->failed(), CliNotFound::create($cli));
+    }
+}

--- a/src/Commands/RestoreCommand.php
+++ b/src/Commands/RestoreCommand.php
@@ -8,12 +8,14 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Wnx\LaravelBackupRestore\Actions\CheckDependenciesAction;
 use Wnx\LaravelBackupRestore\Actions\CleanupLocalBackupAction;
 use Wnx\LaravelBackupRestore\Actions\DecompressBackupAction;
 use Wnx\LaravelBackupRestore\Actions\DownloadBackupAction;
 use Wnx\LaravelBackupRestore\Actions\ImportDumpAction;
 use Wnx\LaravelBackupRestore\Actions\ResetDatabaseAction;
 use Wnx\LaravelBackupRestore\Exceptions\CannotCreateDbImporter;
+use Wnx\LaravelBackupRestore\Exceptions\CliNotFound;
 use Wnx\LaravelBackupRestore\Exceptions\DecompressionFailed;
 use Wnx\LaravelBackupRestore\Exceptions\ImportFailed;
 use Wnx\LaravelBackupRestore\Exceptions\NoBackupsFound;
@@ -39,8 +41,10 @@ class RestoreCommand extends Command
      * @throws CannotCreateDbImporter
      * @throws DecompressionFailed
      * @throws ImportFailed
+     * @throws CliNotFound
      */
     public function handle(
+        CheckDependenciesAction $checkDependenciesAction,
         DownloadBackupAction $downloadBackupAction,
         DecompressBackupAction $decompressBackupAction,
         ResetDatabaseAction $resetDatabaseAction,
@@ -48,6 +52,8 @@ class RestoreCommand extends Command
         CleanupLocalBackupAction $cleanupLocalBackupAction
     ): int {
         $connection = $this->option('connection') ?? config('backup.backup.source.databases')[0];
+
+        $checkDependenciesAction->execute($connection);
 
         $pendingRestore = PendingRestore::make(
             disk: $this->getDestinationDiskToRestoreFrom(),

--- a/src/Databases/DbImporter.php
+++ b/src/Databases/DbImporter.php
@@ -12,6 +12,8 @@ abstract class DbImporter
 {
     abstract public function getImportCommand(string $dumpFile): string;
 
+    abstract public function getCliName(): string;
+
     /**
      * @throws ImportFailed
      */

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -41,6 +41,11 @@ class MySql extends DbImporter
         return $command;
     }
 
+    public function getCliName(): string
+    {
+        return 'mysql';
+    }
+
     private function getMySqlImportCommandForCompressedDump(string $storagePathToDatabaseFile, mixed $temporaryCredentialsFile, string $importToDatabase): string
     {
         return collect([

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -26,4 +26,9 @@ class PostgreSql extends DbImporter
 
         return 'psql -U '.config('database.connections.pgsql.username').' -d '.config('database.connections.pgsql.database').' < '.$dumpFile;
     }
+
+    public function getCliName(): string
+    {
+        return 'psql';
+    }
 }

--- a/src/Databases/Sqlite.php
+++ b/src/Databases/Sqlite.php
@@ -17,4 +17,9 @@ class Sqlite extends DbImporter
 
         return 'sqlite3 '.config('database.connections.sqlite.database').' < '.$dumpFile;
     }
+
+    public function getCliName(): string
+    {
+        return 'gunzip';
+    }
 }

--- a/src/DbImporterFactory.php
+++ b/src/DbImporterFactory.php
@@ -29,6 +29,11 @@ class DbImporterFactory
         return static::forDriver($config['driver']);
     }
 
+    public static function extend(string $driver, DbImporter $callback)
+    {
+        static::$custom[$driver] = $callback;
+    }
+
     /**
      * @throws CannotCreateDbImporter
      */

--- a/src/Exceptions/CliNotFound.php
+++ b/src/Exceptions/CliNotFound.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wnx\LaravelBackupRestore\Exceptions;
+
+use Exception;
+
+class CliNotFound extends Exception
+{
+    public static function create(string $cli): self
+    {
+        return new static("CLI $cli not found. Please ensure $cli is in the PATH and available to your PHP process.");
+    }
+}

--- a/tests/Actions/CheckDependenciesActionTest.php
+++ b/tests/Actions/CheckDependenciesActionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Wnx\LaravelBackupRestore\Actions\CheckDependenciesAction;
+use Wnx\LaravelBackupRestore\Databases\DbImporter;
+use Wnx\LaravelBackupRestore\DbImporterFactory;
+use Wnx\LaravelBackupRestore\Exceptions\CliNotFound;
+
+it('does not throw exception for supported database drivers', function ($connection) {
+    app(CheckDependenciesAction::class)->execute($connection);
+    $this->assertTrue(true);
+})->with(['mysql', 'pgsql', 'sqlite']);
+
+it('throws exception if CLI dependency for given connection can not be found', function () {
+    DbImporterFactory::extend('sqlsrv', new class() extends DbImporter
+    {
+        public function getImportCommand(string $dumpFile): string
+        {
+            return '';
+        }
+
+        public function getCliName(): string
+        {
+            return 'not-existing-cli';
+        }
+    });
+
+    app(CheckDependenciesAction::class)->execute('unsupported-driver');
+
+})
+    ->expectExceptionMessage('CLI not-existing-cli not found. Please ensure not-existing-cli is in the PATH and available to your PHP process.')
+    ->expectException(CliNotFound::class);

--- a/tests/DbImporterFactoryTest.php
+++ b/tests/DbImporterFactoryTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Wnx\LaravelBackupRestore\Databases\DbImporter;
 use Wnx\LaravelBackupRestore\DbImporterFactory;
 use Wnx\LaravelBackupRestore\Exceptions\CannotCreateDbImporter;
 
@@ -33,6 +34,25 @@ it('returns db importer instances for given database driver', function ($connect
         'expected' => \Wnx\LaravelBackupRestore\Databases\PostgreSql::class,
     ],
 ]);
+
+it('returns custom db importer instance for the given database driver', function () {
+    DbImporterFactory::extend('sqlsrv', new class() extends DbImporter
+    {
+        public function getImportCommand(string $dumpFile): string
+        {
+            return 'import-command';
+        }
+
+        public function getCliName(): string
+        {
+            return 'sqlsrv';
+        }
+    });
+
+    $instance = DbImporterFactory::createFromConnection('unsupported-driver');
+
+    expect($instance->getImportCommand())->toEqual('import-command');
+});
 
 it('throws exception if no db importer instance can be created for connection')
     ->tap(fn () => DbImporterFactory::createFromConnection('unsupported'))

--- a/tests/DbImporterFactoryTest.php
+++ b/tests/DbImporterFactoryTest.php
@@ -51,7 +51,7 @@ it('returns custom db importer instance for the given database driver', function
 
     $instance = DbImporterFactory::createFromConnection('unsupported-driver');
 
-    expect($instance->getImportCommand())->toEqual('import-command');
+    expect($instance->getImportCommand('path/to/dump/file'))->toEqual('import-command');
 });
 
 it('throws exception if no db importer instance can be created for connection')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,8 +3,9 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Storage;
-use function Pest\Laravel\artisan;
 use Wnx\LaravelBackupRestore\Tests\TestCase;
+
+use function Pest\Laravel\artisan;
 
 uses(TestCase::class)
     ->beforeEach(function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Storage;
-use Wnx\LaravelBackupRestore\Tests\TestCase;
-
 use function Pest\Laravel\artisan;
+use Wnx\LaravelBackupRestore\Tests\TestCase;
 
 uses(TestCase::class)
     ->beforeEach(function () {


### PR DESCRIPTION
This PR introduces a new "Check CLI Dependencies"-Action, that ensures that `gunzip` and `mysql` or `sqlite` or `psql` are available to the PHP process.

## Why?
Nothing is more frustrating than getting a "MySQL is not available"-error message after downloading a huge backup. This PR should "fix" this by aborting the entire restore process **before** downloading the backup if the CLIs are not available.

In a future release I would like to provide an option to skip the download process entirely and allow users to pass the path to a local backup file; in case they have already downloaded a backup in another way.