### PR TITLE
Drop Support for Laravel 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,12 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.1]
-        laravel: [9.*, 10.*]
+        laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
-            carbon: ^2.63
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "ext-zip": "*",
-        "illuminate/contracts": "^9.0 || ^10.0",
+        "illuminate/contracts": "^10.0",
         "spatie/laravel-backup": "^8.0",
         "spatie/laravel-package-tools": "^1.14.0",
         "spatie/temporary-directory": "^2.0"
@@ -27,7 +27,7 @@
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^6.0 || ^7.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0 || ^8.0",
+        "orchestra/testbench": "^8.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "pestphp/pest-plugin-watch": "1.x-dev",


### PR DESCRIPTION
For easier feature development, we're going to drop support for Laravel 9.
The _core_ functionality of downloading, unpacking and importing a database backup still works in projects using an earlier version of this package.