### PR TITLE
Use Database Connection name when generating import shell command

### DIFF
--- a/src/Actions/ImportDumpAction.php
+++ b/src/Actions/ImportDumpAction.php
@@ -37,7 +37,7 @@ class ImportDumpAction
         $dbDumps->each(function ($dbDump) use ($pendingRestore, $importer) {
             spin(function () use ($importer, $dbDump, $pendingRestore) {
                 $absolutePathToDump = Storage::disk($pendingRestore->restoreDisk)->path($dbDump);
-                $importer->importToDatabase($absolutePathToDump);
+                $importer->importToDatabase($absolutePathToDump, $pendingRestore->connection);
             }, message: 'Importing '.str($dbDump)->afterLast('/')->__toString());
 
             info('Imported '.str($dbDump)->afterLast('/')->__toString());

--- a/src/Databases/DbImporter.php
+++ b/src/Databases/DbImporter.php
@@ -32,7 +32,7 @@ abstract class DbImporter
      */
     public function importToDatabase(string $dumpFile, string $connection): void
     {
-        $process = Process::run($this->getImportCommand($dumpFile. $connection));
+        $process = Process::run($this->getImportCommand($dumpFile, $connection));
 
         $this->checkIfImportWasSuccessful($process, $dumpFile);
     }

--- a/src/Databases/DbImporter.php
+++ b/src/Databases/DbImporter.php
@@ -11,7 +11,7 @@ use Wnx\LaravelBackupRestore\Exceptions\ImportFailed;
 
 abstract class DbImporter
 {
-    abstract public function getImportCommand(string $dumpFile): string;
+    abstract public function getImportCommand(string $dumpFile, string $connection): string;
 
     abstract public function getCliName(): string;
 
@@ -30,9 +30,9 @@ abstract class DbImporter
     /**
      * @throws ImportFailed
      */
-    public function importToDatabase(string $dumpFile): void
+    public function importToDatabase(string $dumpFile, string $connection): void
     {
-        $process = Process::run($this->getImportCommand($dumpFile));
+        $process = Process::run($this->getImportCommand($dumpFile. $connection));
 
         $this->checkIfImportWasSuccessful($process, $dumpFile);
     }

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -11,7 +11,7 @@ class MySql extends DbImporter
 {
     private TemporaryDirectory $temporaryDirectory;
 
-    public function getImportCommand(string $dumpFile): string
+    public function getImportCommand(string $dumpFile, string $connection): string
     {
         $temporaryDirectoryPath = config('backup.backup.temporary_directory') ?? storage_path('app/backup-temp');
 
@@ -21,11 +21,8 @@ class MySql extends DbImporter
             ->create()
             ->empty();
 
-        $dumper = DbDumperFactory::createFromConnection('mysql');
+        $dumper = DbDumperFactory::createFromConnection($connection);
         $importToDatabase = $dumper->getDbName();
-
-        // @todo: Use $pendingRestore->connection
-        // $importToDatabase = $pendingRestore->database;
 
         file_put_contents($this->temporaryDirectory->path('credentials.dat'), $dumper->getContentsOfCredentialsFile());
 

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -19,12 +19,11 @@ class PostgreSql extends DbImporter
         $dumper->getContentsOfCredentialsFile();
 
         // @todo: Improve detection of compressed files
-        // @todo: Use $pendingRestore->connection
         if (str($dumpFile)->endsWith('gz')) {
-            return 'gunzip -c '.$dumpFile.' | psql -U '.config('database.connections.pgsql.username').' -d '.config('database.connections.pgsql.database');
+            return 'gunzip -c '.$dumpFile.' | psql -U '.config("database.connections.{$connection}.username").' -d '.config("database.connections.{$connection}.database");
         }
 
-        return 'psql -U '.config('database.connections.pgsql.username').' -d '.config('database.connections.pgsql.database').' < '.$dumpFile;
+        return 'psql -U '.config("database.connections.{$connection}.username").' -d '.config("database.connections.{$connection}.database").' < '.$dumpFile;
     }
 
     public function getCliName(): string

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -12,10 +12,10 @@ class PostgreSql extends DbImporter
     /**
      * @throws CannotCreateDbDumper
      */
-    public function getImportCommand(string $dumpFile): string
+    public function getImportCommand(string $dumpFile, string $connection): string
     {
         /** @var \Spatie\DbDumper\Databases\PostgreSql $dumper */
-        $dumper = DbDumperFactory::createFromConnection('pgsql');
+        $dumper = DbDumperFactory::createFromConnection($connection);
         $dumper->getContentsOfCredentialsFile();
 
         // @todo: Improve detection of compressed files

--- a/src/Databases/Sqlite.php
+++ b/src/Databases/Sqlite.php
@@ -6,16 +6,16 @@ namespace Wnx\LaravelBackupRestore\Databases;
 
 class Sqlite extends DbImporter
 {
-    public function getImportCommand(string $dumpFile): string
+    public function getImportCommand(string $dumpFile, string $connection): string
     {
         // @todo: Improve detection of compressed files
         // @todo: Use $pendingRestore->connection
         if (str($dumpFile)->endsWith('gz')) {
             // Shell command to import a gzipped SQL file to a sqlite database
-            return 'gunzip -c '.$dumpFile.' | sqlite3 '.config('database.connections.sqlite.database');
+            return 'gunzip -c '.$dumpFile.' | sqlite3 '.config("database.connections.{$connection}.database");
         }
 
-        return 'sqlite3 '.config('database.connections.sqlite.database').' < '.$dumpFile;
+        return 'sqlite3 '.config("database.connections.{$connection}.database").' < '.$dumpFile;
     }
 
     public function getCliName(): string

--- a/src/Databases/Sqlite.php
+++ b/src/Databases/Sqlite.php
@@ -9,7 +9,6 @@ class Sqlite extends DbImporter
     public function getImportCommand(string $dumpFile, string $connection): string
     {
         // @todo: Improve detection of compressed files
-        // @todo: Use $pendingRestore->connection
         if (str($dumpFile)->endsWith('gz')) {
             // Shell command to import a gzipped SQL file to a sqlite database
             return 'gunzip -c '.$dumpFile.' | sqlite3 '.config("database.connections.{$connection}.database");

--- a/tests/Actions/CheckDependenciesActionTest.php
+++ b/tests/Actions/CheckDependenciesActionTest.php
@@ -15,7 +15,7 @@ it('does not throw exception for supported database drivers', function ($connect
 it('throws exception if CLI dependency for given connection can not be found', function () {
     DbImporterFactory::extend('sqlsrv', new class() extends DbImporter
     {
-        public function getImportCommand(string $dumpFile): string
+        public function getImportCommand(string $dumpFile, string $connection): string
         {
             return '';
         }

--- a/tests/Databases/MySqlTest.php
+++ b/tests/Databases/MySqlTest.php
@@ -11,7 +11,7 @@ use Wnx\LaravelBackupRestore\Exceptions\ImportFailed;
 it('imports mysql dump', function (string $dumpFile) {
     Event::fake();
 
-    app(MySql::class)->importToDatabase($dumpFile, 'myql');
+    app(MySql::class)->importToDatabase($dumpFile, 'mysql');
 
     Event::assertDispatched(function (DatabaseDumpImportWasSuccessful $event) use ($dumpFile) {
         return $event->absolutePathToDump === $dumpFile;

--- a/tests/Databases/MySqlTest.php
+++ b/tests/Databases/MySqlTest.php
@@ -11,7 +11,7 @@ use Wnx\LaravelBackupRestore\Exceptions\ImportFailed;
 it('imports mysql dump', function (string $dumpFile) {
     Event::fake();
 
-    app(MySql::class)->importToDatabase($dumpFile);
+    app(MySql::class)->importToDatabase($dumpFile, 'myql');
 
     Event::assertDispatched(function (DatabaseDumpImportWasSuccessful $event) use ($dumpFile) {
         return $event->absolutePathToDump === $dumpFile;
@@ -25,5 +25,5 @@ it('imports mysql dump', function (string $dumpFile) {
 ]);
 
 it('throws import failed exception if mysql dump could not be imported')
-    ->tap(fn () => app(MySql::class)->importToDatabase('file-does-not-exist'))
+    ->tap(fn () => app(MySql::class)->importToDatabase('file-does-not-exist', 'mysql'))
     ->throws(ImportFailed::class);

--- a/tests/Databases/PostgreSqlTest.php
+++ b/tests/Databases/PostgreSqlTest.php
@@ -11,7 +11,7 @@ use Wnx\LaravelBackupRestore\Exceptions\ImportFailed;
 it('imports pgsql dump', function (string $dumpFile) {
     Event::fake();
 
-    app(PostgreSql::class)->importToDatabase($dumpFile);
+    app(PostgreSql::class)->importToDatabase($dumpFile, 'pgsql');
 
     Event::assertDispatched(function (DatabaseDumpImportWasSuccessful $event) use ($dumpFile) {
         return $event->absolutePathToDump === $dumpFile;
@@ -25,6 +25,6 @@ it('imports pgsql dump', function (string $dumpFile) {
 ])->group('pgsql');
 
 it('throws import failed exception if pgsql dump could not be imported')
-    ->tap(fn () => app(PostgreSql::class)->importToDatabase('file-does-not-exist'))
+    ->tap(fn () => app(PostgreSql::class)->importToDatabase('file-does-not-exist', 'pgsql'))
     ->throws(ImportFailed::class)
     ->group('pgsql');

--- a/tests/Databases/SqliteTest.php
+++ b/tests/Databases/SqliteTest.php
@@ -11,7 +11,7 @@ use Wnx\LaravelBackupRestore\Exceptions\ImportFailed;
 it('imports sqlite dump', function (string $dumpFile) {
     Event::fake();
 
-    app(Sqlite::class)->importToDatabase($dumpFile);
+    app(Sqlite::class)->importToDatabase($dumpFile, 'sqlite');
 
     Event::assertDispatched(function (DatabaseDumpImportWasSuccessful $event) use ($dumpFile) {
         return $event->absolutePathToDump === $dumpFile;
@@ -25,5 +25,5 @@ it('imports sqlite dump', function (string $dumpFile) {
 ]);
 
 it('throws import failed exception if sqlite dump could not be imported')
-    ->tap(fn () => app(Sqlite::class)->importToDatabase('file-does-not-exist'))
+    ->tap(fn () => app(Sqlite::class)->importToDatabase('file-does-not-exist', 'sqlite'))
     ->throws(ImportFailed::class);

--- a/tests/DbImporterFactoryTest.php
+++ b/tests/DbImporterFactoryTest.php
@@ -38,7 +38,7 @@ it('returns db importer instances for given database driver', function ($connect
 it('returns custom db importer instance for the given database driver', function () {
     DbImporterFactory::extend('sqlsrv', new class() extends DbImporter
     {
-        public function getImportCommand(string $dumpFile): string
+        public function getImportCommand(string $dumpFile, string $connection): string
         {
             return 'import-command';
         }
@@ -51,7 +51,7 @@ it('returns custom db importer instance for the given database driver', function
 
     $instance = DbImporterFactory::createFromConnection('unsupported-driver');
 
-    expect($instance->getImportCommand('path/to/dump/file'))->toEqual('import-command');
+    expect($instance->getImportCommand('path/to/dump/file', 'connection'))->toEqual('import-command');
 });
 
 it('throws exception if no db importer instance can be created for connection')


### PR DESCRIPTION
This PR tackles #33 and resolves a couple of open todos.
Instead of hard-coding using `mysql`, `sqlite` or `pgsql` connection in the importer, this PR updates the classes to use data from the selected connection name.