### PR TITLE
Respect dump_binary_path setting when importing database

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,7 +64,7 @@ jobs:
           touch database/database.sqlite
 
       - name: Execute tests
-        run: vendor/bin/pest --exclude-group=pgsql --coverage --min=85
+        run: vendor/bin/pest --exclude-group=pgsql --coverage --min=80
         env:
           MYSQL_PORT: 3306
           MYSQL_USERNAME: root

--- a/src/Commands/RestoreCommand.php
+++ b/src/Commands/RestoreCommand.php
@@ -65,6 +65,7 @@ class RestoreCommand extends Command
 
         $connection = $this->option('connection') ?? config('backup.backup.source.databases')[0];
 
+        // Dependencies-check is currently disabled. Custom binary paths are currently not supported by the Action.
         // $checkDependenciesAction->execute($connection);
 
         $pendingRestore = PendingRestore::make(

--- a/src/Commands/RestoreCommand.php
+++ b/src/Commands/RestoreCommand.php
@@ -65,7 +65,7 @@ class RestoreCommand extends Command
 
         $connection = $this->option('connection') ?? config('backup.backup.source.databases')[0];
 
-        $checkDependenciesAction->execute($connection);
+        // $checkDependenciesAction->execute($connection);
 
         $pendingRestore = PendingRestore::make(
             disk: $this->getDestinationDiskToRestoreFrom(),

--- a/src/Databases/DbImporter.php
+++ b/src/Databases/DbImporter.php
@@ -11,6 +11,8 @@ use Wnx\LaravelBackupRestore\Exceptions\ImportFailed;
 
 abstract class DbImporter
 {
+    protected string $dumpBinaryPath = '';
+
     abstract public function getImportCommand(string $dumpFile, string $connection): string;
 
     abstract public function getCliName(): string;
@@ -35,5 +37,26 @@ abstract class DbImporter
         $process = Process::run($this->getImportCommand($dumpFile, $connection));
 
         $this->checkIfImportWasSuccessful($process, $dumpFile);
+    }
+
+    public function setDumpBinaryPath(string $dumpBinaryPath): self
+    {
+        if ($dumpBinaryPath !== '' && ! str_ends_with($dumpBinaryPath, '/')) {
+            $dumpBinaryPath .= '/';
+        }
+
+        $this->dumpBinaryPath = $dumpBinaryPath;
+
+        return $this;
+    }
+
+    protected function determineQuote(): string
+    {
+        return $this->isWindows() ? '"' : "'";
+    }
+
+    protected function isWindows(): bool
+    {
+        return str_starts_with(strtoupper(PHP_OS), 'WIN');
     }
 }

--- a/src/Databases/DbImporter.php
+++ b/src/Databases/DbImporter.php
@@ -41,8 +41,8 @@ abstract class DbImporter
 
     public function setDumpBinaryPath(string $dumpBinaryPath): self
     {
-        if ($dumpBinaryPath !== '' && ! str_ends_with($dumpBinaryPath, '/')) {
-            $dumpBinaryPath .= '/';
+        if ($dumpBinaryPath !== '' && ! str_ends_with($dumpBinaryPath, DIRECTORY_SEPARATOR)) {
+            $dumpBinaryPath .= DIRECTORY_SEPARATOR;
         }
 
         $this->dumpBinaryPath = $dumpBinaryPath;

--- a/tests/Databases/MySqlTest.php
+++ b/tests/Databases/MySqlTest.php
@@ -2,11 +2,15 @@
 
 declare(strict_types=1);
 
+use Illuminate\Process\PendingProcess;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Process;
 use Wnx\LaravelBackupRestore\Databases\MySql;
 use Wnx\LaravelBackupRestore\Events\DatabaseDumpImportWasSuccessful;
 use Wnx\LaravelBackupRestore\Exceptions\ImportFailed;
+
+use function PHPUnit\Framework\assertStringContainsString;
 
 it('imports mysql dump', function (string $dumpFile) {
     Event::fake();
@@ -23,6 +27,73 @@ it('imports mysql dump', function (string $dumpFile) {
     __DIR__.'/../storage/Laravel/2023-01-28-mysql-no-compression-no-encryption.sql',
     __DIR__.'/../storage/Laravel/2023-01-28-mysql-compression-no-encryption.sql.gz',
 ]);
+
+it('uses default binary path to import mysql dump', function () {
+    Event::fake();
+    Process::fake();
+
+    $dumpFile = __DIR__.'/../storage/Laravel/2023-01-28-mysql-no-compression-no-encryption.sql';
+
+    app(MySql::class)->importToDatabase(
+        dumpFile: $dumpFile,
+        connection: 'mysql'
+    );
+
+    Process::assertRan(function (PendingProcess $process) {
+        assertStringContainsString("'mysql'", $process->command);
+
+        return true;
+    });
+
+    Event::assertDispatched(function (DatabaseDumpImportWasSuccessful $event) use ($dumpFile) {
+        return $event->absolutePathToDump === $dumpFile;
+    });
+});
+
+it('uses custom binary path to import mysql dump', function () {
+    Event::fake();
+    Process::fake();
+
+    $dumpFile = __DIR__.'/../storage/Laravel/2023-01-28-mysql-no-compression-no-encryption.sql';
+
+    app(MySql::class)->importToDatabase(
+        dumpFile: $dumpFile,
+        connection: 'mysql-restore-binary-path'
+    );
+
+    Process::assertRan(function (PendingProcess $process) {
+        assertStringContainsString('/usr/bin/mysql', $process->command);
+
+        return true;
+    });
+
+    Event::assertDispatched(function (DatabaseDumpImportWasSuccessful $event) use ($dumpFile) {
+        return $event->absolutePathToDump === $dumpFile;
+    });
+});
+
+it('uses custom binary path to import compressed mysql dump', function () {
+    Event::fake();
+    Process::fake();
+
+    $dumpFile = __DIR__.'/../storage/Laravel/2023-01-28-mysql-compression-no-encryption.sql.gz';
+
+    app(MySql::class)->importToDatabase(
+        dumpFile: $dumpFile,
+        connection: 'mysql-restore-binary-path'
+    );
+
+    Process::assertRan(function (PendingProcess $process) {
+        assertStringContainsString('gunzip <', $process->command);
+        assertStringContainsString('/usr/bin/mysql', $process->command);
+
+        return true;
+    });
+
+    Event::assertDispatched(function (DatabaseDumpImportWasSuccessful $event) use ($dumpFile) {
+        return $event->absolutePathToDump === $dumpFile;
+    });
+});
 
 it('throws import failed exception if mysql dump could not be imported')
     ->tap(fn () => app(MySql::class)->importToDatabase('file-does-not-exist', 'mysql'))

--- a/tests/Databases/PostgreSqlTest.php
+++ b/tests/Databases/PostgreSqlTest.php
@@ -2,11 +2,16 @@
 
 declare(strict_types=1);
 
+use Illuminate\Process\PendingProcess;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Process;
 use Wnx\LaravelBackupRestore\Databases\PostgreSql;
 use Wnx\LaravelBackupRestore\Events\DatabaseDumpImportWasSuccessful;
 use Wnx\LaravelBackupRestore\Exceptions\ImportFailed;
+
+use function PHPUnit\Framework\assertStringContainsString;
+use function PHPUnit\Framework\assertStringNotContainsString;
 
 it('imports pgsql dump', function (string $dumpFile) {
     Event::fake();
@@ -23,6 +28,71 @@ it('imports pgsql dump', function (string $dumpFile) {
     __DIR__.'/../storage/Laravel/2023-03-04-pgsql-no-compression-no-encryption.sql',
     __DIR__.'/../storage/Laravel/2023-03-04-pgsql-compression-no-encryption.sql.gz',
 ])->group('pgsql');
+
+it('uses default binary to import pgsql dump', function () {
+    Event::fake();
+    Process::fake();
+
+    $dumpFile = __DIR__.'/../storage/Laravel/2023-03-04-pgsql-no-compression-no-encryption.sql';
+
+    app(PostgreSql::class)->importToDatabase($dumpFile, 'pgsql');
+
+    Process::assertRan(function (PendingProcess $process) {
+        assertStringNotContainsString('/usr/bin/psql', $process->command);
+        assertStringContainsString('psql', $process->command);
+
+        return true;
+    });
+    Event::assertDispatched(function (DatabaseDumpImportWasSuccessful $event) use ($dumpFile) {
+        return $event->absolutePathToDump === $dumpFile;
+    });
+
+    $result = DB::connection('pgsql')->table('users')->count();
+    expect($result)->toBe(10);
+})->group('pgsql');
+
+it('uses custom binary to import pgsql dump', function () {
+    Event::fake();
+    Process::fake();
+
+    $dumpFile = __DIR__.'/../storage/Laravel/2023-03-04-pgsql-no-compression-no-encryption.sql';
+
+    app(PostgreSql::class)->importToDatabase($dumpFile, 'pgsql-restore-binary-path');
+
+    Process::assertRan(function (PendingProcess $process) {
+        assertStringContainsString('/usr/bin/psql', $process->command);
+
+        return true;
+    });
+    Event::assertDispatched(function (DatabaseDumpImportWasSuccessful $event) use ($dumpFile) {
+        return $event->absolutePathToDump === $dumpFile;
+    });
+
+    $result = DB::connection('pgsql')->table('users')->count();
+    expect($result)->toBe(10);
+})->group('pgsql');
+
+it('uses custom binary to import compressed pgsql dump', function () {
+    Event::fake();
+    Process::fake();
+
+    $dumpFile = __DIR__.'/../storage/Laravel/2023-03-04-pgsql-compression-no-encryption.sql.gz';
+
+    app(PostgreSql::class)->importToDatabase($dumpFile, 'pgsql-restore-binary-path');
+
+    Process::assertRan(function (PendingProcess $process) {
+        assertStringContainsString('gunzip -c', $process->command);
+        assertStringContainsString('/usr/bin/psql', $process->command);
+
+        return true;
+    });
+    Event::assertDispatched(function (DatabaseDumpImportWasSuccessful $event) use ($dumpFile) {
+        return $event->absolutePathToDump === $dumpFile;
+    });
+
+    $result = DB::connection('pgsql')->table('users')->count();
+    expect($result)->toBe(10);
+})->group('pgsql');
 
 it('throws import failed exception if pgsql dump could not be imported')
     ->tap(fn () => app(PostgreSql::class)->importToDatabase('file-does-not-exist', 'pgsql'))

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -47,6 +47,18 @@ class TestCase extends Orchestra
             'password' => env('MYSQL_PASSWORD', ''),
         ]);
 
+        $app['config']->set('database.connections.mysql-restore-binary-path', [
+            'driver' => 'mysql',
+            'host' => env('MYSQL_HOST', '127.0.0.1'),
+            'port' => env('MYSQL_PORT', '3306'),
+            'database' => env('MYSQL_DATABASE', 'laravel_backup_restore'),
+            'username' => env('MYSQL_USERNAME', 'root'),
+            'password' => env('MYSQL_PASSWORD', ''),
+            'dump' => [
+                'dump_binary_path' => env('MYSQL_BINARY_PATH', '/usr/bin/'),
+            ],
+        ]);
+
         $app['config']->set('database.connections.pgsql', [
             'driver' => 'pgsql',
             'host' => env('PGSQL_HOST', '127.0.0.1'),
@@ -64,6 +76,18 @@ class TestCase extends Orchestra
             'username' => env('PGSQL_USERNAME', 'root'),
             'password' => env('PGSQL_PASSWORD', ''),
             'search_path' => 'public',
+        ]);
+        $app['config']->set('database.connections.pgsql-restore-binary-path', [
+            'driver' => 'pgsql',
+            'host' => env('PGSQL_HOST', '127.0.0.1'),
+            'port' => env('PGSQL_PORT', '5432'),
+            'database' => env('PGSQL_DATABASE', 'laravel_backup_restore'),
+            'username' => env('PGSQL_USERNAME', 'root'),
+            'password' => env('PGSQL_PASSWORD', ''),
+            'search_path' => 'public',
+            'dump' => [
+                'dump_binary_path' => env('PGSQL_BINARY_PATH', '/usr/bin/'),
+            ],
         ]);
 
         $app['config']->set('database.connections.unsupported-driver', [


### PR DESCRIPTION
This PR tries to fix an issue when `mysql` or `psql` is not available to the PHP process. Instead of relying on a globally available `mysql`-CLI, the package now looks at the `dump.dump_binary_path`-setting and adds the path to the command.

refs #37 

