### PR TITLE
Use the same logic to check extracted files and extracted DB dumps

### DIFF
--- a/src/Actions/ImportDumpAction.php
+++ b/src/Actions/ImportDumpAction.php
@@ -24,13 +24,13 @@ class ImportDumpAction
      */
     public function execute(PendingRestore $pendingRestore): void
     {
-        if ($pendingRestore->hasNoDbDumpsDirectory()) {
+        $dbDumps = $pendingRestore->getAvailableDbDumps();
+
+        if ($dbDumps->isEmpty()) {
             throw NoDatabaseDumpsFound::notFoundInBackup($pendingRestore);
         }
 
         $importer = DbImporterFactory::createFromConnection($pendingRestore->connection);
-
-        $dbDumps = $pendingRestore->getAvailableDbDumps();
 
         info('Importing database '.str('dump')->plural($dbDumps)->__toString().' …');
 


### PR DESCRIPTION
 - `PendingRestore::hasNoDbDumpsDirectory` checks for any type of files
 - `PendingRestore::getAvailableDbDumps` checks for dumps only

There are few ways to solve the issue. This PR uses `PendingRestore::getAvailableDbDumps` to check existence of dumps; another way - add the same file extension filter to `PendingRestore::hasNoDbDumpsDirectory`. I prefer the current approach to make codebase smaller and do not repeat the logic. But I'm ok to fix `PendingRestore::hasNoDbDumpsDirectory` if you think it's better.


BTW, it was the only usage of `PendingRestore::hasNoDbDumpsDirectory`. I haven't removed this method because it was public and not marked as `@internal` (which means it will be BC break).


___
PS: I discovered this issue debugging my CI check (probably caused by the DB connection misconfiguration), the message was really confusing:

<img width="505" alt="image" src="https://github.com/stefanzweifel/laravel-backup-restore/assets/5278175/226d78a7-1fc3-42d1-b4cb-45d4a010498b">

"dumps" is plural because it should be plural for zero :) 



PPS: How about listing all extracted files in the `NoDatabaseDumpsFound` message? This will improve debugging experience a lot. I can create a PR.
