### PR TITLE
Respect no interaction flag when asking for confirmation

### DIFF
--- a/src/Commands/RestoreCommand.php
+++ b/src/Commands/RestoreCommand.php
@@ -185,6 +185,8 @@ class RestoreCommand extends Command
 
     private function confirmRestoreProcess(PendingRestore $pendingRestore): bool
     {
+        if ($this->option('no-interaction')) return true;
+
         $connectionConfig = config("database.connections.{$pendingRestore->connection}");
         $connectionInformationForConfirmation = collect([
             'Database' => Arr::get($connectionConfig, 'database'),


### PR DESCRIPTION
When someone uses the `--no-interaction` flag, they are still asked for confirmation using an interactive prompt.

This fixes that explicitly.