### PR TITLE
Added support for spatie/laravel-backup v9 and drop support for v8 and PHP 8.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.2, 8.1]
+        php: [8.3, 8.2]
         laravel: ['10.*', '11.*']
         stability: [prefer-lowest, prefer-stable]
         include:
@@ -23,9 +23,6 @@ jobs:
           - laravel: 11.*
             testbench: ^9.0
             carbon: ^2.63
-        exclude:
-          - laravel: 11.*
-            php: 8.1
 
     services:
       mysql:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ phpstan.neon
 vendor
 node_modules
 database/database.sqlite
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A package to restore a database backup created by the [spatie/laravel-backup](https://github.com/spatie/laravel-backup) package.
 
-The package requires Laravel v10.17 or higher and PHP 8.1 or higher.
+The package requires Laravel v10.17 or higher and PHP 8.2 or higher.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-zip": "*",
         "illuminate/contracts": "^10.17.0 || ^11.0",
         "laravel/prompts": "^0.1.11",
-        "spatie/laravel-backup": "^8.0",
+        "spatie/laravel-backup": "^8.0 || ^9.0",
         "spatie/laravel-package-tools": "^1.14.0",
         "spatie/temporary-directory": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-zip": "*",
         "illuminate/contracts": "^10.17.0 || ^11.0",
         "laravel/prompts": "^0.1.11",
-        "spatie/laravel-backup": "^8.0 || ^9.0",
+        "spatie/laravel-backup": "^9.0",
         "spatie/laravel-package-tools": "^1.14.0",
         "spatie/temporary-directory": "^2.0"
     },

--- a/src/Commands/RestoreCommand.php
+++ b/src/Commands/RestoreCommand.php
@@ -68,9 +68,11 @@ class RestoreCommand extends Command
         // Dependencies-check is currently disabled. Custom binary paths are currently not supported by the Action.
         // $checkDependenciesAction->execute($connection);
 
+        $diskToRestoreFrom = $this->getDestinationDiskToRestoreFrom();
+
         $pendingRestore = PendingRestore::make(
-            disk: $this->getDestinationDiskToRestoreFrom(),
-            backup: $this->getBackupToRestore($this->getDestinationDiskToRestoreFrom()),
+            disk: $diskToRestoreFrom,
+            backup: $this->getBackupToRestore($diskToRestoreFrom),
             connection: $connection,
             backupPassword: $this->getPassword(),
         );

--- a/workbench/app/BackupRestoreWorkbenchProvider.php
+++ b/workbench/app/BackupRestoreWorkbenchProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Workbench\App;
 
 use Illuminate\Support\ServiceProvider;
+use ZipArchive;
 
 class BackupRestoreWorkbenchProvider extends ServiceProvider
 {
@@ -73,14 +74,30 @@ class BackupRestoreWorkbenchProvider extends ServiceProvider
             'backup' => [
                 'name' => env('APP_NAME', 'Laravel'),
                 'source' => [
+                    'files' => [
+                        'include' => [
+                            base_path(),
+                        ],
+                        'exclude' => [
+                            base_path('vendor'),
+                            base_path('node_modules'),
+                        ],
+                        'follow_links' => false,
+                        'ignore_unreadable_directories' => false,
+                        'relative_path' => null,
+                    ],
                     'databases' => [
                         'mysql',
                     ],
                 ],
                 'database_dump_compressor' => \Spatie\DbDumper\Compressors\GzipCompressor::class,
+                'database_dump_file_timestamp_format' => null,
+                'database_dump_filename_base' => 'database',
                 'database_dump_file_extension' => '',
 
                 'destination' => [
+                    'compression_method' => ZipArchive::CM_DEFAULT,
+                    'compression_level' => 9,
                     'filename_prefix' => '',
                     'disks' => [
                         'remote',
@@ -89,6 +106,60 @@ class BackupRestoreWorkbenchProvider extends ServiceProvider
                 'temporary_directory' => storage_path('app/backup-temp'),
                 'password' => env('BACKUP_ARCHIVE_PASSWORD'),
                 'encryption' => 'default',
+                'tries' => 1,
+                'retry_delay' => 0,
+            ],
+            'notifications' => [
+                'notifications' => [
+                    \Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification::class => ['mail'],
+                    \Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFoundNotification::class => ['mail'],
+                    \Spatie\Backup\Notifications\Notifications\CleanupHasFailedNotification::class => ['mail'],
+                    \Spatie\Backup\Notifications\Notifications\BackupWasSuccessfulNotification::class => ['mail'],
+                    \Spatie\Backup\Notifications\Notifications\HealthyBackupWasFoundNotification::class => ['mail'],
+                    \Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification::class => ['mail'],
+                ],
+                'notifiable' => \Spatie\Backup\Notifications\Notifiable::class,
+                'mail' => [
+                    'to' => 'your@example.com',
+                    'from' => [
+                        'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+                        'name' => env('MAIL_FROM_NAME', 'Example'),
+                    ],
+                ],
+                'slack' => [
+                    'webhook_url' => '',
+                    'channel' => null,
+                    'username' => null,
+                    'icon' => null,
+                ],
+                'discord' => [
+                    'webhook_url' => '',
+                    'username' => '',
+                    'avatar_url' => '',
+                ],
+            ],
+            'monitor_backups' => [
+                [
+                    'name' => env('APP_NAME', 'laravel-backup'),
+                    'disks' => ['local'],
+                    'health_checks' => [
+                        \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
+                        \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,
+                    ],
+                ],
+            ],
+            'cleanup' => [
+                'strategy' => \Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy::class,
+                'default_strategy' => [
+                    'keep_all_backups_for_days' => 7,
+                    'keep_daily_backups_for_days' => 16,
+                    'keep_weekly_backups_for_weeks' => 8,
+                    'keep_monthly_backups_for_months' => 4,
+                    'keep_yearly_backups_for_years' => 2,
+                    'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
+                ],
+                'tries' => 1,
+                'retry_delay' => 0,
             ],
         ]);
     }


### PR DESCRIPTION
This required all config settings to be present as described in the [upgrade guide](https://github.com/spatie/laravel-backup/blob/main/UPGRADING.md)

Also fixed an issue where the restore command was asking twice for which disk to restore from.