### PR TITLE
Add Support to pass MySQL Options to mysql binary

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -31,9 +31,9 @@ class MySql extends DbImporter
         ];
 
         if (str($dumpFile)->endsWith('sql')) {
-            $command = $this->getMySqlImportCommandForUncompressedDump($importToDatabase, $dumpFile, $credentialsArray);
+            $command = $this->getMySqlImportCommandForUncompressedDump($importToDatabase, $dumpFile, $credentialsArray, $connection);
         } else {
-            $command = $this->getMySqlImportCommandForCompressedDump($dumpFile, $importToDatabase, $credentialsArray);
+            $command = $this->getMySqlImportCommandForCompressedDump($dumpFile, $importToDatabase, $credentialsArray, $connection);
         }
 
         return $command;
@@ -47,7 +47,7 @@ class MySql extends DbImporter
     /**
      * @throws ImportFailed
      */
-    private function getMySqlImportCommandForCompressedDump(string $storagePathToDatabaseFile, string $importToDatabase, array $credentials): string
+    private function getMySqlImportCommandForCompressedDump(string $storagePathToDatabaseFile, string $importToDatabase, array $credentials, string $connection): string
     {
         $quote = $this->determineQuote();
         $password = $credentials['password'];
@@ -67,10 +67,11 @@ class MySql extends DbImporter
             '-P', $credentials['port'],
             isset($credentials['host']) ? '-h '.$credentials['host'] : '',
             $importToDatabase,
+            $this->getOptions($connection),
         ])->filter()->implode(' ');
     }
 
-    private function getMySqlImportCommandForUncompressedDump(string $importToDatabase, string $storagePathToDatabaseFile, array $credentials): string
+    private function getMySqlImportCommandForUncompressedDump(string $importToDatabase, string $storagePathToDatabaseFile, array $credentials, string $connection): string
     {
         $quote = $this->determineQuote();
         $password = $credentials['password'];
@@ -82,8 +83,20 @@ class MySql extends DbImporter
             '-P', $credentials['port'],
             isset($credentials['host']) ? '-h '.$credentials['host'] : '',
             $importToDatabase,
+            $this->getOptions($connection),
             '<',
             $storagePathToDatabaseFile,
+        ])->filter()->implode(' ');
+    }
+
+    private function getOptions(string $connection): string
+    {
+        $options = config("database.connections.{$connection}.dump.options", null);
+        $skipSSL = config("database.connections.{$connection}.dump.skip_ssl", null);
+
+        return collect([
+            $options,
+            $skipSSL ? '--ssl-mode=DISABLED' : '',
         ])->filter()->implode(' ');
     }
 }

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -91,12 +91,6 @@ class MySql extends DbImporter
 
     private function getOptions(string $connection): string
     {
-        $options = config("database.connections.{$connection}.dump.options", null);
-        $skipSSL = config("database.connections.{$connection}.dump.skip_ssl", null);
-
-        return collect([
-            $options,
-            $skipSSL ? '--ssl-mode=DISABLED' : '',
-        ])->filter()->implode(' ');
+        return config("database.connections.{$connection}.dump.options", '');
     }
 }

--- a/src/Events/DatabaseDumpImportWasSuccessful.php
+++ b/src/Events/DatabaseDumpImportWasSuccessful.php
@@ -6,5 +6,5 @@ namespace Wnx\LaravelBackupRestore\Events;
 
 class DatabaseDumpImportWasSuccessful
 {
-    public function __construct(readonly public string $absolutePathToDump) {}
+    public function __construct(public readonly string $absolutePathToDump) {}
 }

--- a/src/Events/DatabaseReset.php
+++ b/src/Events/DatabaseReset.php
@@ -8,5 +8,5 @@ use Wnx\LaravelBackupRestore\PendingRestore;
 
 class DatabaseReset
 {
-    public function __construct(readonly public PendingRestore $pendingRestore) {}
+    public function __construct(public readonly PendingRestore $pendingRestore) {}
 }

--- a/src/Events/DatabaseRestored.php
+++ b/src/Events/DatabaseRestored.php
@@ -8,5 +8,5 @@ use Wnx\LaravelBackupRestore\PendingRestore;
 
 class DatabaseRestored
 {
-    public function __construct(readonly public PendingRestore $pendingRestore) {}
+    public function __construct(public readonly PendingRestore $pendingRestore) {}
 }

--- a/src/HealthChecks/Result.php
+++ b/src/HealthChecks/Result.php
@@ -9,7 +9,7 @@ use Illuminate\Console\Command;
 class Result
 {
     public function __construct(
-        readonly public HealthCheck $healthCheck,
+        public readonly HealthCheck $healthCheck,
         public int $status,
         public ?string $message,
     ) {

--- a/src/PendingRestore.php
+++ b/src/PendingRestore.php
@@ -12,13 +12,13 @@ use SensitiveParameter;
 class PendingRestore
 {
     public function __construct(
-        readonly public string $disk,
-        readonly public string $backup,
-        readonly public string $connection,
-        readonly public string $restoreId,
-        readonly public string $restoreName,
-        #[SensitiveParameter] readonly public ?string $backupPassword = null,
-        readonly public string $restoreDisk = 'local',
+        public readonly string $disk,
+        public readonly string $backup,
+        public readonly string $connection,
+        public readonly string $restoreId,
+        public readonly string $restoreName,
+        #[SensitiveParameter] public readonly ?string $backupPassword = null,
+        public readonly string $restoreDisk = 'local',
     ) {
         //
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,6 +36,9 @@ class TestCase extends Orchestra
             'database' => env('MYSQL_DATABASE', 'laravel_backup_restore'),
             'username' => env('MYSQL_USERNAME', 'root'),
             'password' => env('MYSQL_PASSWORD', ''),
+            'dump' => [
+                'skip_ssl' => true,
+            ],
         ]);
 
         $app['config']->set('database.connections.mysql-restore', [


### PR DESCRIPTION
This PR introduces improvements to the MySQL datbase import process by allowing custom options (such as skipping SSL) to be configured per database connection.

This is a first-draft of this feature, which I would like to build upon and improve in future versions.