### PR TITLE
Fix grammar in ImportFailed exception message

### DIFF
--- a/src/Exceptions/ImportFailed.php
+++ b/src/Exceptions/ImportFailed.php
@@ -13,7 +13,7 @@ class ImportFailed extends Exception
     {
         $processOutput = static::formatProcessOutput($process);
 
-        return new static("The import process failed with a none successful exitcode.{$processOutput}");
+        return new static("The import process failed with a non-successful exit code.{$processOutput}");
     }
 
     public static function decompressionFailed(string $filename, string $reason): static


### PR DESCRIPTION
Hi! Small grammatical cleanup in the message thrown by `ImportFailed::processDidNotEndSuccessfully()`.

**Before:** `The import process failed with a none successful exitcode.`
**After:**  `The import process failed with a non-successful exit code.`

Two corrections:
- "none successful" → "non-successful"
- "exitcode" → "exit code"

This message surfaces in logs whenever a restore process exits non-zero, so the cleanup makes log output read a bit more naturally. No behavior change.