### PR TITLE
Enhance dump file path validation and add related tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12,7 +12,7 @@ parameters:
 
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: src/Exceptions/DecompressionFailed.php
 
 		-

--- a/src/Actions/DecompressBackupAction.php
+++ b/src/Actions/DecompressBackupAction.php
@@ -32,6 +32,13 @@ class DecompressBackupAction
                 $zip->setPassword($pendingRestore->backupPassword);
             }
 
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $entryName = $zip->getNameIndex($i);
+                if ($entryName !== false) {
+                    $this->validateZipEntry($entryName, $pathToFileToDecompress);
+                }
+            }
+
             spin(function () use ($pathToFileToDecompress, $extractTo, $zip) {
                 $extractionResult = $zip->extractTo($extractTo);
                 $zip->close();
@@ -44,6 +51,34 @@ class DecompressBackupAction
             info('Extracted database dump from backup.');
         } else {
             throw DecompressionFailed::create($result, $pathToFileToDecompress);
+        }
+    }
+
+    /**
+     * @throws DecompressionFailed
+     */
+    private function validateZipEntry(string $entryName, string $archivePath): void
+    {
+        // Reject null bytes, POSIX absolute paths, and Windows absolute paths
+        if (str_contains($entryName, "\0")
+            || str_starts_with($entryName, '/')
+            || str_starts_with($entryName, '\\')
+            || preg_match('/^[A-Za-z]:/', $entryName) === 1
+        ) {
+            throw DecompressionFailed::pathTraversalDetected($entryName, $archivePath);
+        }
+
+        // Reject ".." segments that would escape the extraction root
+        $depth = 0;
+        foreach (preg_split('#[/\\\\]#', $entryName) as $segment) {
+            if ($segment === '..') {
+                $depth--;
+                if ($depth < 0) {
+                    throw DecompressionFailed::pathTraversalDetected($entryName, $archivePath);
+                }
+            } elseif ($segment !== '.' && $segment !== '') {
+                $depth++;
+            }
         }
     }
 }

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -53,8 +53,8 @@ class MySql extends DbImporter
         $password = $credentials['password'];
 
         $decompressCommand = match (File::extension($storagePathToDatabaseFile)) {
-            'gz' => "gunzip < {$storagePathToDatabaseFile}",
-            'bz2' => "bunzip2 -c {$storagePathToDatabaseFile}",
+            'gz' => 'gunzip < '.escapeshellarg($storagePathToDatabaseFile),
+            'bz2' => 'bunzip2 -c '.escapeshellarg($storagePathToDatabaseFile),
             default => throw ImportFailed::decompressionFailed($storagePathToDatabaseFile, 'Unknown compression format'),
         };
 
@@ -85,7 +85,7 @@ class MySql extends DbImporter
             $importToDatabase,
             $this->getOptions($connection),
             '<',
-            $storagePathToDatabaseFile,
+            escapeshellarg($storagePathToDatabaseFile),
         ])->filter()->implode(' ');
     }
 

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -38,7 +38,7 @@ class PostgreSql extends DbImporter
                 $host.':'.
                 $port.'/'.
                 $database,
-                '< '.$dumpFile,
+                '< '.escapeshellarg($dumpFile),
             ])->implode(' ');
         }
 
@@ -55,8 +55,8 @@ class PostgreSql extends DbImporter
 
         // @todo: Improve detection of compressed files
         $decompressCommand = match (File::extension($dumpFile)) {
-            'gz' => "gunzip -c {$dumpFile}",
-            'bz2' => "bunzip2 -c {$dumpFile}",
+            'gz' => 'gunzip -c '.escapeshellarg($dumpFile),
+            'bz2' => 'bunzip2 -c '.escapeshellarg($dumpFile),
             default => throw ImportFailed::decompressionFailed($dumpFile, 'Unknown compression format'),
         };
 

--- a/src/Databases/Sqlite.php
+++ b/src/Databases/Sqlite.php
@@ -15,17 +15,17 @@ class Sqlite extends DbImporter
     public function getImportCommand(string $dumpFile, string $connection): string
     {
         if (str($dumpFile)->endsWith('sql')) {
-            return 'sqlite3 '.config("database.connections.{$connection}.database").' < '.$dumpFile;
+            return 'sqlite3 '.escapeshellarg(config("database.connections.{$connection}.database")).' < '.escapeshellarg($dumpFile);
         }
 
         // @todo: Improve detection of compressed files
         $decompressCommand = match (File::extension($dumpFile)) {
-            'gz' => "gunzip -c {$dumpFile}",
-            'bz2' => "bunzip2 -c {$dumpFile}",
+            'gz' => 'gunzip -c '.escapeshellarg($dumpFile),
+            'bz2' => 'bunzip2 -c '.escapeshellarg($dumpFile),
             default => throw ImportFailed::decompressionFailed($dumpFile, 'Unknown compression format'),
         };
 
-        return "$decompressCommand | sqlite3 ".config("database.connections.{$connection}.database");
+        return $decompressCommand.' | sqlite3 '.escapeshellarg(config("database.connections.{$connection}.database"));
     }
 
     public function getCliName(): string

--- a/src/Exceptions/DecompressionFailed.php
+++ b/src/Exceptions/DecompressionFailed.php
@@ -22,6 +22,11 @@ class DecompressionFailed extends Exception
         ZipArchive::ER_SEEK => 'The file %filename% can\'t be sought. (ZipArchive::ER_SEEK)',
     ];
 
+    public static function pathTraversalDetected(string $entryName, string $archive): static
+    {
+        return new static("ZIP entry \"{$entryName}\" in \"{$archive}\" was rejected due to a path traversal attempt.");
+    }
+
     public static function create($errorCode, $filename): static
     {
         return new static(str_replace(

--- a/src/PendingRestore.php
+++ b/src/PendingRestore.php
@@ -83,6 +83,7 @@ class PendingRestore
         $backupDatabaseDumpFileExtensionWithLeadingDot = ".{$backupDatabaseDumpFileExtension}";
 
         return $this->getAvailableFilesInDbDumpsDirectory()
+            ->filter(fn ($file) => preg_match('/^[A-Za-z0-9._-]+$/', basename($file)) === 1)
             ->filter(fn ($file) => Str::endsWith($file, ['.sql', '.sql.gz', '.sql.bz2', $backupDatabaseDumpFileExtensionWithLeadingDot]));
     }
 }

--- a/tests/Actions/DecompressBackupActionTest.php
+++ b/tests/Actions/DecompressBackupActionTest.php
@@ -56,6 +56,55 @@ it('throws DecompressionFailed exception', function () {
     ->throws(DecompressionFailed::class)
     ->expectExceptionMessage('Not a zip archive. (ZipArchive::ER_NOZIP)');
 
+it('throws DecompressionFailed when zip contains a path traversal entry using dot-dot segments', function () {
+    $pendingRestore = PendingRestore::make(
+        disk: 'remote',
+        backup: 'Laravel/crafted-traversal.zip',
+        connection: 'mysql',
+    );
+
+    $tmpPath = tempnam(sys_get_temp_dir(), 'lbr-test-').'.zip';
+    $zip = new ZipArchive;
+    $zip->open($tmpPath, ZipArchive::CREATE);
+    $zip->addFromString('db-dumps/legitimate.sql', '-- harmless SQL');
+    $zip->addFromString('../../../crafted-outside.sql', '-- evil');
+    $zip->close();
+
+    Storage::disk('local')->put(
+        $pendingRestore->getPathToLocalCompressedBackup(),
+        file_get_contents($tmpPath)
+    );
+    unlink($tmpPath);
+
+    app(DecompressBackupAction::class)->execute($pendingRestore);
+})
+    ->throws(DecompressionFailed::class)
+    ->expectExceptionMessage('path traversal');
+
+it('throws DecompressionFailed when zip contains an entry with dot-dot that escapes after a real directory', function () {
+    $pendingRestore = PendingRestore::make(
+        disk: 'remote',
+        backup: 'Laravel/crafted-traversal.zip',
+        connection: 'mysql',
+    );
+
+    $tmpPath = tempnam(sys_get_temp_dir(), 'lbr-test-').'.zip';
+    $zip = new ZipArchive;
+    $zip->open($tmpPath, ZipArchive::CREATE);
+    $zip->addFromString('db-dumps/../../outside.sql', '-- evil');
+    $zip->close();
+
+    Storage::disk('local')->put(
+        $pendingRestore->getPathToLocalCompressedBackup(),
+        file_get_contents($tmpPath)
+    );
+    unlink($tmpPath);
+
+    app(DecompressBackupAction::class)->execute($pendingRestore);
+})
+    ->throws(DecompressionFailed::class)
+    ->expectExceptionMessage('path traversal');
+
 it('throws exception if backup password is wrong', function () {
     $pendingRestore = PendingRestore::make(
         disk: 'remote',

--- a/tests/Databases/MySqlTest.php
+++ b/tests/Databases/MySqlTest.php
@@ -99,3 +99,27 @@ it('uses custom binary path to import compressed mysql dump', function () {
 it('throws import failed exception if mysql dump could not be imported')
     ->tap(fn () => app(MySql::class)->importToDatabase('file-does-not-exist', 'mysql'))
     ->throws(ImportFailed::class);
+
+it('shell-escapes the dump path in the uncompressed mysql import command', function () {
+    $maliciousPath = '/tmp/backup.sql;touch /tmp/lbr_security_test;#.sql';
+
+    $command = app(MySql::class)->getImportCommand($maliciousPath, 'mysql-restore');
+
+    expect($command)->toContain(escapeshellarg($maliciousPath));
+});
+
+it('shell-escapes the dump path in the compressed gz mysql import command', function () {
+    $maliciousPath = '/tmp/backup.sql;touch /tmp/lbr_security_test;#.sql.gz';
+
+    $command = app(MySql::class)->getImportCommand($maliciousPath, 'mysql-restore');
+
+    expect($command)->toContain(escapeshellarg($maliciousPath));
+});
+
+it('shell-escapes the dump path in the compressed bz2 mysql import command', function () {
+    $maliciousPath = '/tmp/backup.sql;touch /tmp/lbr_security_test;#.sql.bz2';
+
+    $command = app(MySql::class)->getImportCommand($maliciousPath, 'mysql-restore');
+
+    expect($command)->toContain(escapeshellarg($maliciousPath));
+});

--- a/tests/Databases/PostgreSqlTest.php
+++ b/tests/Databases/PostgreSqlTest.php
@@ -90,3 +90,27 @@ it('throws import failed exception if pgsql dump could not be imported')
     ->tap(fn () => app(PostgreSql::class)->importToDatabase('file-does-not-exist', 'pgsql'))
     ->throws(ImportFailed::class)
     ->group('pgsql');
+
+it('shell-escapes the dump path in the uncompressed pgsql import command', function () {
+    $maliciousPath = '/tmp/backup.sql;touch /tmp/lbr_security_test;#.sql';
+
+    $command = app(PostgreSql::class)->getImportCommand($maliciousPath, 'pgsql');
+
+    expect($command)->toContain(escapeshellarg($maliciousPath));
+})->group('pgsql');
+
+it('shell-escapes the dump path in the compressed gz pgsql import command', function () {
+    $maliciousPath = '/tmp/backup.sql;touch /tmp/lbr_security_test;#.sql.gz';
+
+    $command = app(PostgreSql::class)->getImportCommand($maliciousPath, 'pgsql');
+
+    expect($command)->toContain(escapeshellarg($maliciousPath));
+})->group('pgsql');
+
+it('shell-escapes the dump path in the compressed bz2 pgsql import command', function () {
+    $maliciousPath = '/tmp/backup.sql;touch /tmp/lbr_security_test;#.sql.bz2';
+
+    $command = app(PostgreSql::class)->getImportCommand($maliciousPath, 'pgsql');
+
+    expect($command)->toContain(escapeshellarg($maliciousPath));
+})->group('pgsql');

--- a/tests/Databases/SqliteTest.php
+++ b/tests/Databases/SqliteTest.php
@@ -28,3 +28,27 @@ it('imports sqlite dump', function (string $dumpFile) {
 it('throws import failed exception if sqlite dump could not be imported')
     ->tap(fn () => app(Sqlite::class)->importToDatabase('file-does-not-exist', 'sqlite'))
     ->throws(ImportFailed::class);
+
+it('shell-escapes the dump path in the uncompressed sqlite import command', function () {
+    $maliciousPath = '/tmp/backup.sql;touch /tmp/lbr_security_test;#.sql';
+
+    $command = app(Sqlite::class)->getImportCommand($maliciousPath, 'sqlite');
+
+    expect($command)->toContain(escapeshellarg($maliciousPath));
+});
+
+it('shell-escapes the dump path in the compressed gz sqlite import command', function () {
+    $maliciousPath = '/tmp/backup.sql;touch /tmp/lbr_security_test;#.sql.gz';
+
+    $command = app(Sqlite::class)->getImportCommand($maliciousPath, 'sqlite');
+
+    expect($command)->toContain(escapeshellarg($maliciousPath));
+});
+
+it('shell-escapes the dump path in the compressed bz2 sqlite import command', function () {
+    $maliciousPath = '/tmp/backup.sql;touch /tmp/lbr_security_test;#.sql.bz2';
+
+    $command = app(Sqlite::class)->getImportCommand($maliciousPath, 'sqlite');
+
+    expect($command)->toContain(escapeshellarg($maliciousPath));
+});

--- a/tests/PendingRestoreTest.php
+++ b/tests/PendingRestoreTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Storage;
+use Wnx\LaravelBackupRestore\PendingRestore;
+
+it('returns only dump files whose basenames contain safe characters', function () {
+    $pendingRestore = PendingRestore::make(
+        disk: 'remote',
+        backup: 'Laravel/test.zip',
+        connection: 'mysql',
+    );
+
+    $dbDumpsPath = $pendingRestore->getPathToLocalDecompressedBackup().DIRECTORY_SEPARATOR.'db-dumps';
+
+    Storage::disk('local')->put($dbDumpsPath.DIRECTORY_SEPARATOR.'legitimate.sql', '-- SQL');
+    Storage::disk('local')->put($dbDumpsPath.DIRECTORY_SEPARATOR.'also-fine_2024.sql.gz', '-- SQL');
+
+    $dumps = $pendingRestore->getAvailableDbDumps();
+
+    expect($dumps)->toHaveCount(2);
+});
+
+it('excludes dump files whose basename contains shell metacharacters (CWE-78)', function (string $maliciousName) {
+    $pendingRestore = PendingRestore::make(
+        disk: 'remote',
+        backup: 'Laravel/test.zip',
+        connection: 'mysql',
+    );
+
+    $dbDumpsPath = $pendingRestore->getPathToLocalDecompressedBackup().DIRECTORY_SEPARATOR.'db-dumps';
+
+    Storage::disk('local')->put($dbDumpsPath.DIRECTORY_SEPARATOR.'legitimate.sql', '-- SQL');
+    Storage::disk('local')->put($dbDumpsPath.DIRECTORY_SEPARATOR.$maliciousName, '-- SQL');
+
+    $dumps = $pendingRestore->getAvailableDbDumps();
+
+    expect($dumps)->toHaveCount(1)
+        ->and($dumps->values()->first())->toEndWith('legitimate.sql');
+})->with([
+    'semicolon injection' => ['backup.sql;touch /tmp/lbr_pwned;#.sql'],
+    'pipe injection' => ['backup|whoami.sql'],
+    'command substitution' => ['backup$(id).sql'],
+    'backtick substitution' => ['backup`id`.sql'],
+    'space in name' => ['backup file.sql'],
+    'ampersand injection' => ['backup&id.sql'],
+]);


### PR DESCRIPTION
Fixes https://github.com/stefanzweifel/laravel-backup-restore/security/advisories/GHSA-w9mx-xmg4-gc4r

---

This pull request introduces significant security improvements to the backup restore process, primarily by preventing path traversal attacks during ZIP decompression and ensuring all database dump file paths are safely shell-escaped before being used in system commands. It also adds stricter filtering of dump files to allow only safe filenames and extends the test suite to verify these protections.

**Security improvements for ZIP decompression:**

* Added a `validateZipEntry` method in `DecompressBackupAction` to reject ZIP entries with null bytes, absolute paths, or path traversal attempts using `..` segments, raising a `DecompressionFailed` exception if detected. [[1]](diffhunk://#diff-358cd68a027ffabbd11be8c430239353b8361a9b4a2c5277dc669545b3688214R35-R41) [[2]](diffhunk://#diff-358cd68a027ffabbd11be8c430239353b8361a9b4a2c5277dc669545b3688214R56-R83) [[3]](diffhunk://#diff-7bbdba63b96778048a5d10398bc190d23a5789ffefdc2d8dc69ae086b750b869R25-R29)
* Updated the PHPStan baseline to account for the new usage of `new static()` in the custom exception.
* Added tests to verify that ZIP files with path traversal entries are correctly rejected.

**Shell command safety for database imports:**

* Updated MySQL, PostgreSQL, and SQLite import commands to use `escapeshellarg()` for all dump file paths, preventing command injection vulnerabilities. [[1]](diffhunk://#diff-00919064f8b8f5c4a0981d874b57712ea4fcf5d3caf6da450c4bf43c92ccc579L56-R57) [[2]](diffhunk://#diff-00919064f8b8f5c4a0981d874b57712ea4fcf5d3caf6da450c4bf43c92ccc579L88-R88) [[3]](diffhunk://#diff-959b6f9faa2ecee20eee9e4d27481143a03d888e7e53016528e601486f06d2e4L41-R41) [[4]](diffhunk://#diff-959b6f9faa2ecee20eee9e4d27481143a03d888e7e53016528e601486f06d2e4L58-R59) [[5]](diffhunk://#diff-5e42da7231aedf54d0a4507580386e2c5f0e8505905c7b12951fb74d4ff8cac4L18-R28)
* Added tests for each database type to ensure the dump file paths are properly shell-escaped in all import command variants. [[1]](diffhunk://#diff-82d5d254cabc47cd7998270317bf4193e3b4cdd9f9e6ada5bf48c4f98e509100R102-R125) [[2]](diffhunk://#diff-a6cc964ba0dad6e4366a7f7dc81269f0eecaf6eb18baba5f69cf7b08c16058d4R93-R116) [[3]](diffhunk://#diff-716235057e3b6e4de129a57ff3da83d944fbb414cfa46a14973e69d04eaaf026R31-R54)

**Safe dump file discovery:**

* Modified `PendingRestore::getAvailableDbDumps()` to only include files whose basenames match a strict whitelist of safe characters, excluding files with shell metacharacters or spaces.
* Added tests to verify that only safe dump files are returned and maliciously named files are excluded.