### PR TITLE
Use --backup connection ealier

### DIFF
--- a/src/Commands/RestoreCommand.php
+++ b/src/Commands/RestoreCommand.php
@@ -131,6 +131,10 @@ class RestoreCommand extends Command
      */
     private function getBackupToRestore(string $disk): string
     {
+        if ($this->option('backup') && $this->option('backup') !== 'latest') {
+            return $this->option('backup');
+        }
+
         $name = config('backup.backup.name');
 
         info("Fetch list of backups from $disk …");
@@ -144,10 +148,6 @@ class RestoreCommand extends Command
 
         if ($this->option('backup') === 'latest') {
             return $listOfBackups->last();
-        }
-
-        if ($this->option('backup')) {
-            return $this->option('backup');
         }
 
         $labelLength = 60;

--- a/tests/Commands/RestoreCommandTest.php
+++ b/tests/Commands/RestoreCommandTest.php
@@ -182,6 +182,26 @@ it('shows error message if health check after import fails', function () {
         ->assertFailed();
 });
 
+it('restores backup when --backup path is in a different directory than config backup name', function () {
+    // Simulate a multi-tenant scenario where the backup lives under a different name
+    // than config('backup.backup.name'). Without the fix this throws NoBackupsFound
+    // because the code would list files under the config name directory first.
+    config(['backup.backup.name' => 'NonExistentApp']);
+
+    $this->artisan(RestoreCommand::class, [
+        '--disk' => 'remote',
+        '--backup' => 'Laravel/2023-02-28-sqlite-no-compression-no-encryption.zip',
+        '--connection' => 'sqlite-restore',
+        '--no-interaction' => true,
+    ])
+        ->expectsQuestion('Proceed to restore "Laravel/2023-02-28-sqlite-no-compression-no-encryption.zip" using the "sqlite-restore" database connection. (Database: database/database.sqlite)', true)
+        ->assertSuccessful();
+
+    $result = DB::connection('sqlite')->table('users')->count();
+
+    expect($result)->toBe(10);
+})->group('sqlite');
+
 it('does not clear downloaded backup if --keep option is being used', function () {
     Event::fake([LocalBackupRemoved::class]);
 


### PR DESCRIPTION
Fixed #117 

---

This pull request improves the backup restoration process in the `RestoreCommand` by allowing users to restore from a specific backup path, even if it is located in a different directory than the configured backup name. This addresses issues in multi-tenant scenarios and ensures more flexible and reliable restores. The changes also include a new test to verify this behavior.

**Restore logic improvements:**

* Updated `getBackupToRestore` in `RestoreCommand.php` to immediately return the specified `--backup` option if provided and not equal to `latest`, avoiding unnecessary directory lookups and fixing issues when the backup is in a different directory than the configured backup name. [[1]](diffhunk://#diff-9058ada4e29e711d75a31a383021d0f69b97a3a1566d6a5cabffb16ebc0025b3R134-R137) [[2]](diffhunk://#diff-9058ada4e29e711d75a31a383021d0f69b97a3a1566d6a5cabffb16ebc0025b3L149-L152)

**Testing enhancements:**

* Added a test in `RestoreCommandTest.php` to verify that restoration works when the `--backup` path is in a different directory from the configured backup name, simulating a multi-tenant scenario.